### PR TITLE
Add Zack Newman into Maintainers list.

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -118,3 +118,4 @@ This Technical Charter sets forth the responsibilities and procedures for techni
    * Josef Šimánek (RubyGems)
    * Myles Borins (GitHub / npm)
    * Trevor Rosen (GitHub / npm)
+   * Zack Newman (Chainguard)


### PR DESCRIPTION
As discussed at last meeting, it would be handy to add Zack Newman into list of Maintainers.

There were no objectives.