### PR TITLE
Remove Jacques Chester from CHARTER.md

### DIFF
--- a/CHARTER.md
+++ b/CHARTER.md
@@ -113,7 +113,6 @@ This Technical Charter sets forth the responsibilities and procedures for techni
    * Brian Fox (Sonatype / Maven Central)
    * Dustin Ingram (Google / PyPI)
    * Jacob Finkelman / Eh2406 (Cargo)
-   * Jacques Chester (Shopify)
    * Jason Swank (Sonatype / Maven Central)
    * Josef Šimánek (RubyGems)
    * Myles Borins (GitHub / npm)


### PR DESCRIPTION
As I will no longer be working in a job focused on repository matters, I am resigning from the working group. Because I will not be active my name should be removed from voting members.