### PR TITLE
Reorganize the content on repos.openssf.org

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,24 +1,26 @@
 # OpenSSF Securing Software Repositories Working Group
 
-This is a list of materials (surveys, documents, proposals, and so on) released by the [OpenSSF Securing Software Repositories Working Group](https://github.com/ossf/wg-securing-software-repos).
+The motivation of the working group is to focus on helping maintainers of software repositories, software registries, and tools which rely on them. It is both a forum to share experiences and discuss shared problems (for more information, see [Communication](https://github.com/ossf/wg-securing-software-repos?tab=readme-ov-file#communication)) as well as a place to publish content to benefit package repositories.
 
-## Surveys
-
-* [The Package Manager Landscape Survey](https://github.com/ossf/wg-securing-software-repos/blob/main/survey/2022/README.md) - December 2022
-  > A survey/landscape of different security mechanisms and features that are implemented across the different ecosystems as they pertain to security critical user journeys.
-
-## Documents
-
-* [Trusted Publishers for All Package Repositories](https://repos.openssf.org/trusted-publishers-for-all-package-repositories) - July 2024
-  > Guidance for package repositories in adopting Trusted Publishers to authenticate publishing from hosted build environments without using long-lived credentials.
+## Maturity Model
 
 * [Principles for Package Repository Security](https://repos.openssf.org/principles-for-package-repository-security) - February 2024
   > A security maturity model for package repositories, for assessing current capabilities and roadmapping future improvements.
 
+## Implementation Guidance
+
+* [Trusted Publishers for All Package Repositories](https://repos.openssf.org/trusted-publishers-for-all-package-repositories) - July 2024
+  > Guidance for package repositories in adopting Trusted Publishers to authenticate publishing from hosted build environments without using long-lived credentials.
+
 * [Build Provenance for All Package Registries](https://repos.openssf.org/build-provenance-for-all-package-registries) - July 2023
   > Guidance for package registries in adopting build provenance to verifiably link a package back to its source code and build instructions.
 
-## Proposals
+
+## Proposals, Surveys, and Other Work
 
 * [Build Provenance and Code-signing for Homebrew](https://repos.openssf.org/proposals/build-provenance-and-code-signing-for-homebrew) - July 2023
   > A proposal for introducing build provenance and cryptographic signatures to the Homebrew package manager.
+This is a list of materials (surveys, documents, proposals, and so on) released by the [OpenSSF Securing Software Repositories Working Group](https://github.com/ossf/wg-securing-software-repos).
+
+* [The Package Manager Landscape Survey](https://github.com/ossf/wg-securing-software-repos/blob/main/survey/2022/README.md) - December 2022
+  > A survey/landscape of different security mechanisms and features that are implemented across the different ecosystems as they pertain to security critical user journeys.


### PR DESCRIPTION
I'm going to point some folks at https://repos.openssf.org/ tomorrow at a talk at BlueHat, and I thought it'd be helpful to organize the content a bit on that page.