### PR TITLE
fix: replace job_workflow_ref with workflow_ref

### DIFF
--- a/docs/trusted-publishers-for-all-package-repositories.md
+++ b/docs/trusted-publishers-for-all-package-repositories.md
@@ -20,7 +20,7 @@ For some Trusted Publishing providers, Trusted Publishers allow binding verifiab
 
 Trusted Publishers are ideal for package repositories that accept user-built packages, like PyPI and RubyGems, as opposed to package repositories that have centralized build infrastructure like Homebrew.
 
-Trusted Publishers pairs well with other technologies such as SLSA build provenance, as it is built on the same underlying technology, the OIDC standard. 
+Trusted Publishers pairs well with other technologies such as SLSA build provenance, as it is built on the same underlying technology, the OIDC standard.
 
 Package repositories which don’t host separate artifacts (such as pkg.go.dev) don’t require authenticating with the repository, thus Trusted Publishers isn’t applicable.
 
@@ -46,7 +46,7 @@ A high-level overview of how PyPI verifies the OIDC ID token against a pre-confi
     * `repository` is `example-repo`
     * `repository_owner` is `example-owner`
     * `repository_owner_id` is `12345`
-    * `job_workflow_ref` is `example-owner/example-repo/.github/workflows/publish.yml@abcdef`
+    * `workflow_ref` is `example-owner/example-repo/.github/workflows/publish.yml@abcdef`
 
 Once this is complete, the package repository can authorize publications by delegating to a repository-managed token.
 


### PR DESCRIPTION
TL;DR: `job_workflow_ref` and `workflow_ref` are
*often* the same thing and have the same value,
but sometimes diverge in ways that make later
support for GitHub's reusable workflows difficult.

This guide should recommend `workflow_ref` instead of `job_workflow_ref` for the "baseline" of Trusted
Publishing, since it's always correct as the
"initiating" workflow identity.

See https://github.com/pypi/warehouse/issues/11096 and https://github.com/rust-lang/crates.io/pull/11131#discussion_r2083661244 for more context.

CC @sethmlarson 